### PR TITLE
Improved test coverage of the worker.

### DIFF
--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/QueueMustStop.php
+++ b/src/QueueMustStop.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace MaxBrokman\SafeQueue;
+
+/**
+ * Interface QueueMustStop used in testing to force a stop.
+ */
+interface QueueMustStop
+{
+}

--- a/src/Stopper.php
+++ b/src/Stopper.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace MaxBrokman\SafeQueue;
+
+class Stopper
+{
+    public function stop()
+    {
+        exit; //@codeCoverageIgnore
+    }
+}

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -18,6 +18,10 @@ class Worker extends IlluminateWorker
      * @var EntityManager
      */
     private $entityManager;
+    /**
+     * @var Stopper
+     */
+    private $stopper;
 
     /**
      * Worker constructor.
@@ -25,16 +29,65 @@ class Worker extends IlluminateWorker
      * @param FailedJobProviderInterface $failer
      * @param Dispatcher                 $events
      * @param EntityManager              $entityManager
+     * @param Stopper                    $stopper
      */
     public function __construct(
         QueueManager $manager,
         FailedJobProviderInterface $failer,
         Dispatcher $events,
-        EntityManager $entityManager
+        EntityManager $entityManager,
+        Stopper $stopper
     ) {
         parent::__construct($manager, $failer, $events);
 
         $this->entityManager = $entityManager;
+        $this->stopper       = $stopper;
+    }
+
+    /**
+     * Listen to the given queue and work jobs from it without re-booting the framework.
+     *
+     * This is a slight re-working of the parent implementation to aid testing.
+     *
+     * @param  string $connectionName
+     * @param  null   $queue
+     * @param  int    $delay
+     * @param  int    $memory
+     * @param  int    $sleep
+     * @param  int    $maxTries
+     * @return void
+     */
+    public function daemon($connectionName, $queue = null, $delay = 0, $memory = 128, $sleep = 3, $maxTries = 0)
+    {
+        $lastRestart = $this->getTimestampOfLastQueueRestart();
+
+        while (true) {
+            if ($this->daemonShouldRun()) {
+                $canContinue = $this->runNextJobForDaemon(
+                    $connectionName, $queue, $delay, $sleep, $maxTries
+                );
+
+                if ($canContinue === false) {
+                    break;
+                }
+            } else {
+                $this->sleep($sleep);
+            }
+
+            if ($this->memoryExceeded($memory) || $this->queueShouldRestart($lastRestart)) {
+                break;
+            }
+        }
+
+        $this->stop();
+    }
+
+    /**
+     * Overridden to allow testing.
+     */
+    public function stop()
+    {
+        $this->stopper->stop();
     }
 
     /**
@@ -44,45 +97,71 @@ class Worker extends IlluminateWorker
      * We also clear the entity manager before working a job for good measure, this will help us better
      * simulate a single request model.
      *
-     * @param string $connectionName
-     * @param string $queue
-     * @param int    $delay
-     * @param int    $sleep
-     * @param int    $maxTries
+     * @param  string $connectionName
+     * @param  string $queue
+     * @param  int    $delay
+     * @param  int    $sleep
+     * @param  int    $maxTries
+     * @return bool
      */
     protected function runNextJobForDaemon($connectionName, $queue, $delay, $sleep, $maxTries)
     {
         $this->entityManager->clear();
 
-        $this->assertEntityManagerOpen();
+        try {
+            $this->assertEntityManagerOpen();
+        } catch (EntityManagerClosedException $e) {
+            if ($this->exceptions) {
+                $this->exceptions->report(new EntityManagerClosedException);
+            }
+
+            return false;
+        }
+
         $this->assertGoodDatabaseConnection();
 
         try {
             $this->pop($connectionName, $queue, $delay, $sleep, $maxTries);
         } catch (Exception $e) {
+            //dd($e);
             if ($this->exceptions) {
                 $this->exceptions->report($e);
             }
+
+            if ($e instanceof QueueMustStop) {
+                return false;
+            }
         } catch (Throwable $e) {
+            dd($e);
             if ($this->exceptions) {
                 $this->exceptions->report(new FatalThrowableError($e));
             }
+
+            if ($e instanceof QueueMustStop) {
+                return false;
+            }
         }
+
+        return true;
     }
 
+    /**
+     * @throws EntityManagerClosedException
+     */
     private function assertEntityManagerOpen()
     {
         if ($this->entityManager->isOpen()) {
             return;
         }
 
-        if ($this->exceptions) {
-            $this->exceptions->report(new EntityManagerClosedException);
-        }
-
-        $this->stop();
+        throw new EntityManagerClosedException;
     }
 
+    /**
+     * Some database systems close the connection after a period of time, in MySQL this is system variable
+     * `wait_timeout`. Given the daemon is meant to run indefinitely we need to make sure we have an open
+     * connection before working any job. Otherwise we would see `MySQL has gone away` type errors.
+     */
     private function assertGoodDatabaseConnection()
     {
         $connection = $this->entityManager->getConnection();

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -123,7 +123,6 @@ class Worker extends IlluminateWorker
         try {
             $this->pop($connectionName, $queue, $delay, $sleep, $maxTries);
         } catch (Exception $e) {
-            //dd($e);
             if ($this->exceptions) {
                 $this->exceptions->report($e);
             }
@@ -132,7 +131,6 @@ class Worker extends IlluminateWorker
                 return false;
             }
         } catch (Throwable $e) {
-            dd($e);
             if ($this->exceptions) {
                 $this->exceptions->report(new FatalThrowableError($e));
             }

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -3,12 +3,19 @@
 
 namespace tests\MaxBrokman\SafeQueue;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
 use Illuminate\Contracts\Cache\Repository;
+use Illuminate\Contracts\Debug\ExceptionHandler as Handler;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Queue\Failed\FailedJobProviderInterface;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\Worker as IlluminateWorker;
+use MaxBrokman\SafeQueue\EntityManagerClosedException;
+use MaxBrokman\SafeQueue\QueueMustStop;
+use MaxBrokman\SafeQueue\Stopper;
 use MaxBrokman\SafeQueue\Worker;
 use Mockery as m;
 
@@ -18,6 +25,11 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
      * @var QueueManager|m\MockInterface
      */
     private $queueManager;
+
+    /**
+     * @var Queue|m\MockInterface
+     */
+    private $queue;
 
     /**
      * @var FailedJobProviderInterface|m\MockInterface
@@ -35,10 +47,23 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
     private $entityManager;
 
     /**
+     * @var Connection|m\MockInterface
+     */
+    private $dbConnection;
+
+    /**
      * @var Repository|m\MockInterface
      */
     private $cache;
 
+    /**
+     * @var Handler|m\MockInterface
+     */
+    private $exceptions;
+    /**
+     * @var Stopper|m\MockInterface
+     */
+    private $stopper;
     /**
      * @var Worker
      */
@@ -47,13 +72,28 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->queueManager  = m::mock(QueueManager::class);
+        $this->queue         = m::mock(Queue::class);
         $this->failedJobs    = m::mock(FailedJobProviderInterface::class);
         $this->dispatcher    = m::mock(Dispatcher::class);
         $this->entityManager = m::mock(EntityManager::class);
+        $this->dbConnection  = m::mock(Connection::class);
         $this->cache         = m::mock(Repository::class);
+        $this->exceptions    = m::mock(Handler::class);
+        $this->stopper       = m::mock(Stopper::class);
 
-        $this->worker = new Worker($this->queueManager, $this->failedJobs, $this->dispatcher, $this->entityManager);
-        $this->worker->setCache($this->cache);
+        $this->worker = new Worker($this->queueManager, $this->failedJobs, $this->dispatcher, $this->entityManager,
+            $this->stopper);
+
+        $this->worker->setDaemonExceptionHandler($this->exceptions);
+
+        // Not interested in events
+        $this->dispatcher->shouldIgnoreMissing();
+
+        // EM will get cleared every run
+        $this->entityManager->shouldReceive('clear');
+
+        // EM always has connection available
+        $this->entityManager->shouldReceive('getConnection')->andReturn($this->dbConnection);
     }
 
     protected function tearDown()
@@ -61,8 +101,115 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
         m::close();
     }
 
+    protected function prepareToRunJob($job)
+    {
+        if ($job instanceof Job) {
+            $jobs = [$job];
+        } else {
+            $jobs = $job;
+        }
+
+        $this->queueManager->shouldReceive('isDownForMaintenance')->andReturn(false);
+        $this->queueManager->shouldReceive('connection')->andReturn($this->queue);
+        $this->queueManager->shouldReceive('getName')->andReturn('test');
+
+        $popExpectation = $this->queue->shouldReceive('pop');
+        call_user_func_array([$popExpectation, 'andReturn'], $jobs);
+    }
+
     public function testExtendsLaravelWorker()
     {
         $this->assertInstanceOf(IlluminateWorker::class, $this->worker);
     }
+
+    public function testStopWhenEntityManagerClosed()
+    {
+        // Entity manager will report closed but will have a connection
+        $this->entityManager->shouldReceive('isOpen')->andReturn(false);
+        $this->dbConnection->shouldReceive('ping')->andReturn(true);
+
+        // We must log this fact
+        $this->exceptions->shouldReceive('report')->with(m::type(EntityManagerClosedException::class))->once();
+
+        // We must stop
+        $this->stopper->shouldReceive('stop')->once();
+
+        // Make a job
+        $job = m::mock(Job::class);
+        $job->shouldReceive('fire')->never();
+        $this->prepareToRunJob($job);
+
+        $this->worker->daemon('test', null, 0, 128, 3, 0);
+    }
+
+    public function testReconnected()
+    {
+        // Entity manager will report open but has no connection, must reconnect
+        $this->entityManager->shouldReceive('isOpen')->andReturn(true);
+
+        $this->dbConnection->shouldReceive('ping')->andReturn(false);
+        $this->dbConnection->shouldReceive('close')->once();
+        $this->dbConnection->shouldReceive('connect')->once();
+
+        // We must stop
+        $this->stopper->shouldReceive('stop')->once();
+        // We must log this fact
+        $this->exceptions->shouldReceive('report')->with(m::type(BadThingHappened::class))->once();
+
+        // Make a job
+        $job = m::mock(Job::class);
+
+        // Needed just to make it stop
+        $job->shouldReceive('fire')->once()->andThrow(new BadThingHappened());
+        $job->shouldIgnoreMissing();
+        $this->prepareToRunJob($job);
+
+        $this->worker->daemon('test', null, 0, 128, 3, 0);
+    }
+
+    public function testLoops()
+    {
+        // Entity manager will report open and good connection
+        $this->entityManager->shouldReceive('isOpen')->andReturn(true)->times(2);
+        $this->dbConnection->shouldReceive('ping')->andReturn(true)->times(2);
+
+        // We must stop
+        $this->stopper->shouldReceive('stop')->once();
+
+        // Make a job
+        $jobOne = m::mock(Job::class);
+        $jobTwo = m::mock(Job::class);
+
+        $jobOne->shouldReceive('fire')->once();
+        $jobOne->shouldIgnoreMissing();
+
+        $jobTwo->shouldReceive('fire')->once()->andThrow(new BadThingHappened());
+        $jobTwo->shouldIgnoreMissing();
+
+        $this->exceptions->shouldReceive('report')->with(m::type(BadThingHappened::class))->once();
+
+        $this->prepareToRunJob([$jobOne, $jobTwo]);
+
+        $this->worker->daemon('test', null, 0, 128, 3, 0);
+    }
+
+    public function testRestartsNicely()
+    {
+        $this->worker->setCache($this->cache);
+
+        // Different times during a job is the restart condition
+        $this->cache->shouldReceive('get')->with('illuminate:queue:restart')->andReturn(1, 2);
+
+        // Force it to not run
+        $this->queueManager->shouldReceive('isDownForMaintenance')->andReturn(true);
+
+        // We must stop
+        $this->stopper->shouldReceive('stop')->once();
+
+        $this->worker->daemon('test', null, 0, 128, 0, 0);
+    }
+}
+
+class BadThingHappened extends \Exception implements QueueMustStop
+{
 }


### PR DESCRIPTION
This meant making some changes to how the worker works, including extra scaffolding to allow tests to happen over code that is designed not to exit. The result is the worker is now further from the Laravel base class.
