### PR TITLE
Publish config file so user can control name of WorkCommand.

### DIFF
--- a/config/safequeue.php
+++ b/config/safequeue.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Worker Command Name
+    |--------------------------------------------------------------------------
+    |
+    | Configure the signature / name of the Work Command here. The default
+    | is to rename the command to 'doctrine:queue:work', however you can
+    | rename it to whatever you want by changing this value.
+    |
+    | To override the Laravel 'queue:work' command name just set this
+    | to a false value or 'queue:work'.
+    |
+    */
+    'command_name' => 'doctrine:queue:work',
+
+];

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -8,7 +8,7 @@ use MaxBrokman\SafeQueue\Worker;
 
 class WorkCommand extends IlluminateWorkCommand
 {
-    const SIGNATURE_REGEX_PATTERN = '/([\w\:]+)(?=\s|\{)/i';
+    const SIGNATURE_REGEX_PATTERN = '/([\w:-]+)(?=\s|\{)/i';
 
     /**
      * The console command description.
@@ -34,11 +34,11 @@ class WorkCommand extends IlluminateWorkCommand
     {
         if ($commandName) {
             /**
-             * RegEx matches signature from the Laravel Worker Command that we're
-             * extending from. Captures 1+ word characters and/or literal colon
-             * (:), up to the first white-space character or a literal opening
-             * curly brace ({). The match is then replaced with the command
-             * name from config, and the result is a renamed signature.
+             * RegEx matches signature from the Laravel Worker Command that we're extending
+             * from. Captures 1+ word characters (a-zA-Z0-9_) and/or literal colon (:),
+             * and\or literal hyphen (-), up to the first white-space character or a
+             * literal opening curly brace ({). The match is then replaced with the
+             * command name from config, and the result is a renamed signature.
              */
             $this->signature = preg_replace(
                 self::SIGNATURE_REGEX_PATTERN, $commandName,  $this->signature, 1

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -8,6 +8,8 @@ use MaxBrokman\SafeQueue\Worker;
 
 class WorkCommand extends IlluminateWorkCommand
 {
+    const SIGNATURE_REGEX_PATTERN = '/([\w\:]+)(?=\s|\{)/i';
+
     /**
      * The console command description.
      *
@@ -31,8 +33,15 @@ class WorkCommand extends IlluminateWorkCommand
     public function renameCommandInSignature($commandName)
     {
         if ($commandName) {
+            /**
+             * RegEx matches signature from the Laravel Worker Command that we're
+             * extending from. Captures 1+ word characters and/or literal colon
+             * (:), up to the first white-space character or a literal opening
+             * curly brace ({). The match is then replaced with the command
+             * name from config, and the result is a renamed signature.
+             */
             $this->signature = preg_replace(
-                '/([\w\:]+)(?=\s|\{)/i', $commandName,  $this->signature, 1
+                self::SIGNATURE_REGEX_PATTERN, $commandName,  $this->signature, 1
             );
         }
     }

--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -9,15 +9,6 @@ use MaxBrokman\SafeQueue\Worker;
 class WorkCommand extends IlluminateWorkCommand
 {
     /**
-     * The console command name. This is now used to rename the laravel
-     * command. It's also used in the tests to ensure the command
-     * is renamed properly.
-     *
-     * @var string
-     */
-    protected $name = 'doctrine:queue:work';
-
-    /**
      * The console command description.
      *
      * @var string
@@ -26,17 +17,23 @@ class WorkCommand extends IlluminateWorkCommand
 
     /**
      * WorkCommand constructor.
+     *
      * @param Worker $worker
+     * @param array  $config
      */
-    public function __construct(Worker $worker)
+    public function __construct(Worker $worker, $config)
     {
-        $this->renameCommandInSignature();
+        $this->renameCommandInSignature($config['command_name']);
 
         parent::__construct($worker);
     }
 
-    public function renameCommandInSignature()
+    public function renameCommandInSignature($commandName)
     {
-        $this->signature = str_replace('queue:work', $this->name, $this->signature);
+        if ($commandName) {
+            $this->signature = preg_replace(
+                '/([\w\:]+)(?=\s|\{)/i', $commandName,  $this->signature, 1
+            );
+        }
     }
 }

--- a/src/DoctrineQueueProvider.php
+++ b/src/DoctrineQueueProvider.php
@@ -60,8 +60,6 @@ class DoctrineQueueProvider extends ServiceProvider
                 $app['config']->get('safequeue')
             );
         });
-
-        //$this->commands('command.safeQueue.work');
     }
 
     /**

--- a/src/DoctrineQueueProvider.php
+++ b/src/DoctrineQueueProvider.php
@@ -18,6 +18,14 @@ class DoctrineQueueProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->publishes([
+            __DIR__ . '/../config/safequeue.php' => config_path('safequeue.php'),
+        ], 'safequeue');
+
+        $this->mergeConfigFrom(
+            __DIR__ . '/../config/safequeue.php', 'safequeue'
+        );
+
         $this->registerWorker();
     }
 
@@ -40,7 +48,10 @@ class DoctrineQueueProvider extends ServiceProvider
     protected function registerWorkCommand()
     {
         $this->app->singleton('command.safeQueue.work', function ($app) {
-            return new WorkCommand($app['safeQueue.worker']);
+            return new WorkCommand(
+                $app['safeQueue.worker'],
+                $app['config']->get('safequeue')
+            );
         });
 
         $this->commands('command.safeQueue.work');

--- a/src/DoctrineQueueProvider.php
+++ b/src/DoctrineQueueProvider.php
@@ -11,6 +11,8 @@ use MaxBrokman\SafeQueue\Console\WorkCommand;
  */
 class DoctrineQueueProvider extends ServiceProvider
 {
+    protected $defer = true;
+
     /**
      * Register the service provider.
      *
@@ -27,6 +29,11 @@ class DoctrineQueueProvider extends ServiceProvider
         );
 
         $this->registerWorker();
+    }
+
+    public function boot()
+    {
+        $this->commands('command.safeQueue.work');
     }
 
     /**
@@ -54,6 +61,19 @@ class DoctrineQueueProvider extends ServiceProvider
             );
         });
 
-        $this->commands('command.safeQueue.work');
+        //$this->commands('command.safeQueue.work');
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [
+            'safeQueue.worker',
+            'command.safeQueue.work'
+        ];
     }
 }

--- a/tests/Console/WorkCommandTest.php
+++ b/tests/Console/WorkCommandTest.php
@@ -26,9 +26,9 @@ class WorkCommandTest extends \PHPUnit_Framework_TestCase
     private $defaultCommandName;
 
     /**
-     * @var string
+     * @var array
      */
-    private $testNewCommandName;
+    private $testNewCommandNames;
 
     /**
      * @var array
@@ -38,10 +38,15 @@ class WorkCommandTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->worker = m::mock(Worker::class);
-        $this->configStub = ['command_name' => 'doctrine:queue:work'];
-        $this->command = new WorkCommand($this->worker, $this->configStub);
         $this->defaultCommandName = 'doctrine:queue:work';
-        $this->testNewCommandName = 'queue:work';
+        $this->configStub = ['command_name' => $this->defaultCommandName];
+        $this->command = new WorkCommand($this->worker, $this->configStub);
+        $this->testNewCommandNames = [
+            'queue:work',
+            'custom-queue:work',
+            'doctrine-queue-work',
+            'doctrine123-queue-work',
+        ];
     }
 
     public function testHasCorrectWorker()
@@ -74,13 +79,16 @@ class WorkCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testCommandNameCanBeConfigured()
     {
-        $this->command = new WorkCommand($this->worker, [
-            'command_name' => $this->testNewCommandName
-        ]);
+        foreach($this->testNewCommandNames as $newCommandName) {
 
-        $signature = $this->getPropertyViaReflection('signature');
+            $this->command = new WorkCommand($this->worker, [
+                'command_name' => $newCommandName
+            ]);
 
-        $this->assertEquals($this->testNewCommandName, $this->getCommandNameFromSignature($signature));
+            $signature = $this->getPropertyViaReflection('signature');
+
+            $this->assertEquals($newCommandName, $this->getCommandNameFromSignature($signature));
+        }
     }
 
     public function testCommandNameCanConfiguredToLaravelDefaultBySettingConfigValueToFalse()

--- a/tests/Console/WorkCommandTest.php
+++ b/tests/Console/WorkCommandTest.php
@@ -96,7 +96,7 @@ class WorkCommandTest extends \PHPUnit_Framework_TestCase
 
     private function getCommandNameFromSignature($signature)
     {
-        preg_match('/([\w\:]+)(?=\s|\{)/i', $signature, $matches);
+        preg_match(WorkCommand::SIGNATURE_REGEX_PATTERN, $signature, $matches);
 
         return $matches[1];
     }


### PR DESCRIPTION
Publish config file so user can control name of WorkCommand. Makes it possible to override the laravel queue:work command, and therefore makes it compatible with Forge. Run php artisan vendor:publish --tag=config to publish config.