### PR TITLE
Replace EntityManager with EntityManagerInterface

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -3,7 +3,7 @@
 
 namespace MaxBrokman\SafeQueue;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -16,22 +16,22 @@ use Throwable;
 /*final*/ class Worker extends IlluminateWorker
 {
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     private $entityManager;
 
     /**
      * Worker constructor.
      *
-     * @param QueueManager     $manager
-     * @param Dispatcher       $events
-     * @param EntityManager    $entityManager
-     * @param ExceptionHandler $exceptions
+     * @param QueueManager              $manager
+     * @param Dispatcher                $events
+     * @param EntityManagerInterface    $entityManager
+     * @param ExceptionHandler          $exceptions
      */
     public function __construct(
         QueueManager $manager,
         Dispatcher $events,
-        EntityManager $entityManager,
+        EntityManagerInterface $entityManager,
         ExceptionHandler $exceptions
     ) {
         parent::__construct($manager, $events, $exceptions);


### PR DESCRIPTION
Making a small change so that the worker type hints the interface rather than the class. This is to support alternative implementations of the EM. (In my case I'm using a proxy object. I should be able to just implement the interface, but I need to extend the EM in order for this worker to use it.)