### PR TITLE
Increase resilience of worker by breaking out the "fetch job" vs "do job" parts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
+  - 7.1
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - php: 7.0
 
 before_script:
   - composer install --no-interaction --dev --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "illuminate/queue": "^5.3.24",
         "laravel-doctrine/orm": "^1.0"
     },

--- a/src/Exceptions/EntityManagerClosedException.php
+++ b/src/Exceptions/EntityManagerClosedException.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace MaxBrokman\SafeQueue;
+namespace MaxBrokman\SafeQueue\Exceptions;
 
 use Exception;
 

--- a/src/Exceptions/QueueFailureException.php
+++ b/src/Exceptions/QueueFailureException.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace MaxBrokman\SafeQueue\Exceptions;
+
+use MaxBrokman\SafeQueue\QueueFailure;
+use Throwable;
+
+class QueueFailureException extends \Exception implements QueueFailure
+{
+    public function __construct(Throwable $previous = null)
+    {
+        parent::__construct("Unable to fetch job from queue", 500, $previous);
+    }
+}

--- a/src/QueueFailure.php
+++ b/src/QueueFailure.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace MaxBrokman\SafeQueue;
+
+/**
+ * Interface QueueMustStop used in testing to force a stop.
+ */
+interface QueueFailure
+{
+}

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -12,6 +12,7 @@ use Illuminate\Queue\Failed\FailedJobProviderInterface;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\Worker as IlluminateWorker;
 use Illuminate\Queue\WorkerOptions;
+use MaxBrokman\SafeQueue\Exceptions\EntityManagerClosedException;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Throwable;
 

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -19,6 +19,7 @@ use MaxBrokman\SafeQueue\QueueMustStop;
 use MaxBrokman\SafeQueue\Stopper;
 use MaxBrokman\SafeQueue\Worker;
 use Mockery as m;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 
 class WorkerTest extends \PHPUnit_Framework_TestCase
 {
@@ -160,7 +161,7 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
         // We must stop
         $this->stopper->shouldReceive('stop')->once();
         // We must log this fact
-        $this->exceptions->shouldReceive('report')->with(m::type(BadThingHappened::class))->once();
+        $this->exceptions->shouldReceive('report')->with(m::type(FatalThrowableError::class))->once();
 
         // Make a job
         $job = m::mock(Job::class);
@@ -192,7 +193,7 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
         $jobTwo->shouldReceive('fire')->once()->andThrow(new BadThingHappened());
         $jobTwo->shouldIgnoreMissing();
 
-        $this->exceptions->shouldReceive('report')->with(m::type(BadThingHappened::class))->once();
+        $this->exceptions->shouldReceive('report')->with(m::type(FatalThrowableError::class))->once();
 
         $this->prepareToRunJob([$jobOne, $jobTwo]);
 

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -125,14 +125,8 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
         call_user_func_array([$popExpectation, 'andReturn'], $jobs);
     }
 
-    protected function prepareToRunJobFails($job)
+    protected function prepareToRunJobFails()
     {
-        if ($job instanceof Job) {
-            $jobs = [$job];
-        } else {
-            $jobs = $job;
-        }
-
         $this->queueManager->shouldReceive('isDownForMaintenance')->andReturn(false);
         $this->queueManager->shouldReceive('connection')->andReturn($this->queue);
         $this->queueManager->shouldReceive('getName')->andReturn('test');
@@ -193,8 +187,8 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
     public function testLoops()
     {
         // Entity manager will report open and good connection
-        $this->entityManager->shouldReceive('isOpen')->andReturn(true)->times(2);
-        $this->dbConnection->shouldReceive('ping')->andReturn(true)->times(2);
+        $this->entityManager->shouldReceive('isOpen')->andReturn(true)->times(3);
+        $this->dbConnection->shouldReceive('ping')->andReturn(true)->times(3);
 
         // We must stop
         $this->stopper->shouldReceive('stop')->once();
@@ -211,7 +205,7 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
 
         $this->exceptions->shouldReceive('report')->with(m::type(FatalThrowableError::class))->once();
 
-        $this->prepareToRunJob([$jobOne, $jobTwo]);
+        $this->prepareToRunJob([null, $jobOne, $jobTwo]);
 
         $this->worker->daemon('test', null, $this->options);
     }
@@ -246,7 +240,7 @@ class WorkerTest extends \PHPUnit_Framework_TestCase
 
         $this->exceptions->shouldReceive('report')->with(m::type(FatalThrowableError::class))->once();
 
-        $this->prepareToRunJobFails([$job]);
+        $this->prepareToRunJobFails();
 
         $this->worker->daemon('test', null, $this->options);
     }

--- a/tests/WorkerTest.php
+++ b/tests/WorkerTest.php
@@ -14,7 +14,7 @@ use Illuminate\Queue\Failed\FailedJobProviderInterface;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Queue\Worker as IlluminateWorker;
 use Illuminate\Queue\WorkerOptions;
-use MaxBrokman\SafeQueue\EntityManagerClosedException;
+use MaxBrokman\SafeQueue\Exceptions\EntityManagerClosedException;
 use MaxBrokman\SafeQueue\QueueMustStop;
 use MaxBrokman\SafeQueue\Stopper;
 use MaxBrokman\SafeQueue\Worker;


### PR DESCRIPTION
In a situation where the worker fails to be able to communicate with it's job provider i.e. Redis it will fail with an exception. The only way to get it to resolve a new Redis server (assuming some sort of HA setup) is to restart the worker - this is because PHP, rather helpfully, caches name lookups.

By breaking out fetching of jobs from doing of jobs you're able to catch that possible case and cause the worker to exit (and be restarted by whatever scheduling tool you're using). In our situation this results in a new resolution to the revived/hot spare Redis instance and a working queue.